### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -3,6 +3,9 @@
 
 name: Python
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/openaleph/ftm-lakehouse/security/code-scanning/5](https://github.com/openaleph/ftm-lakehouse/security/code-scanning/5)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults.  
Best single fix here: insert

```yml
permissions:
  contents: read
```

directly under `name:` and before `on:` in `.github/workflows/python.yml`.

Why this is best: it addresses the CodeQL finding with minimal behavioral change and documents intended token scope globally. If later a specific job/action needs elevated scope, that can be added per job without broadening all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
